### PR TITLE
[Feat] 이메일 발송/검증 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     // Smtp
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Retry
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 
     // ArcUnit
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.2'
+
+    // Smtp
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -12,3 +12,17 @@ create table users
     updated_by bigint                                null comment '수정자',
     status     varchar(20) default 'ACTIVE'          not null comment '상태'
 );
+
+create table email_verify_token
+(
+    id         bigint auto_increment primary key comment '고유번호',
+    token      varchar(50) UNIQUE                    not null comment '토큰',
+    email      varchar(50)                           not null comment '이메일',
+    expires_at datetime    default CURRENT_TIMESTAMP not null comment '만료시간',
+    consume_at datetime                              null comment '사용자 인증 시간',
+    created_at datetime    default CURRENT_TIMESTAMP null comment '생성일',
+    created_by bigint                                null comment '생성자',
+    updated_at datetime                              null comment '수정일',
+    updated_by bigint                                null comment '수정자',
+    status     varchar(20) default 'ACTIVE'          not null comment '상태'
+);

--- a/src/main/java/com/ticket/concert/application/auth/AuthService.java
+++ b/src/main/java/com/ticket/concert/application/auth/AuthService.java
@@ -1,4 +1,4 @@
-package com.ticket.concert.application;
+package com.ticket.concert.application.auth;
 
 import com.ticket.concert.domain.LoginUser;
 import com.ticket.concert.domain.user.User;

--- a/src/main/java/com/ticket/concert/application/dto/mail/request/MailSendRequest.java
+++ b/src/main/java/com/ticket/concert/application/dto/mail/request/MailSendRequest.java
@@ -1,0 +1,12 @@
+package com.ticket.concert.application.dto.mail.request;
+
+import com.ticket.concert.global.regex.UserRegex;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MailSendRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Pattern(regexp = UserRegex.EMAIL, message = "이메일 형식을 확인해주세요.")
+        String email
+) {
+}

--- a/src/main/java/com/ticket/concert/application/email/EmailService.java
+++ b/src/main/java/com/ticket/concert/application/email/EmailService.java
@@ -1,13 +1,20 @@
 package com.ticket.concert.application.email;
 
 import com.ticket.concert.application.dto.mail.request.MailSendRequest;
+import com.ticket.concert.domain.constant.Status;
 import com.ticket.concert.domain.email.EmailSender;
+import com.ticket.concert.domain.email.EmailVerifyToken;
+import com.ticket.concert.domain.email.EmailVerifyTokenRepository;
+import com.ticket.concert.global.exception.BusinessException;
+import com.ticket.concert.global.exception.constant.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -16,17 +23,17 @@ import java.util.UUID;
 public class EmailService {
 
     private static final Duration TOKEN_TTL = Duration.ofMinutes(30);
-    // 토큰 저장소
 
     @Value("${app.base-url}")
     private String baseUrl;
 
     private final EmailSender emailSender;
+    private final EmailVerifyTokenRepository emailVerifyTokenRepository;
 
+    @Transactional
     public void sendEmail(MailSendRequest request) {
         String token = generateUUID();
-        // 토큰 저장소에 저장
-        // tokenRepository.save(token, email, TOKEN_TTL);
+        saveEmailVerifyToken(request.email(), token);
 
         String verifyUrl = generateVerifyUrl(token);
         String htmlBody = buildHtml(verifyUrl);
@@ -35,6 +42,12 @@ public class EmailService {
 
     private String generateUUID() {
         return UUID.randomUUID().toString();
+    }
+
+    private void saveEmailVerifyToken(String email, String token) {
+        LocalDateTime expiresAt = LocalDateTime.now().plus(TOKEN_TTL);
+        Long generatedId = emailVerifyTokenRepository.save(token, email, expiresAt);
+        log.info("[EMAIL_VERIFY_TOKEN] save success. tokenId={}", generatedId);
     }
 
     private String generateVerifyUrl(String token) {
@@ -58,6 +71,29 @@ public class EmailService {
                   </p>
                 </div>
                 """.formatted(verifyUrl, verifyUrl);
+    }
+
+    @Transactional
+    public void verifyToken(String token) {
+        EmailVerifyToken emailVerifyToken = findByEmailVerifyTokenOrThrow(token);
+        validateConsumable(emailVerifyToken);
+        updateConsume(emailVerifyToken);
+    }
+
+    private EmailVerifyToken findByEmailVerifyTokenOrThrow(String token) {
+        return emailVerifyTokenRepository.findByTokenAndStatus(token, Status.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_TOKEN_NOT_FOUND));
+    }
+
+    private void validateConsumable(EmailVerifyToken emailVerifyToken) {
+        if (!emailVerifyToken.isConsumable()) {
+            throw new BusinessException(ErrorCode.EMAIL_TOKEN_NOT_USABLE);
+        }
+    }
+
+    private void updateConsume(EmailVerifyToken emailVerifyToken) {
+        emailVerifyTokenRepository.updateConsumeAt(emailVerifyToken.getToken(), Status.ACTIVE);
+        log.info("[EMAIL_VERIFY_TOKEN] consume update success. tokenId={}", emailVerifyToken.getId());
     }
 
 }

--- a/src/main/java/com/ticket/concert/application/email/EmailService.java
+++ b/src/main/java/com/ticket/concert/application/email/EmailService.java
@@ -29,6 +29,7 @@ public class EmailService {
 
     private final EmailSender emailSender;
     private final EmailVerifyTokenRepository emailVerifyTokenRepository;
+    private final EmailTemplateRenderer emailTemplateRenderer;
 
     @Transactional
     public void sendEmail(MailSendRequest request) {
@@ -36,7 +37,7 @@ public class EmailService {
         saveEmailVerifyToken(request.email(), token);
 
         String verifyUrl = generateVerifyUrl(token);
-        String htmlBody = buildHtml(verifyUrl);
+        String htmlBody = emailTemplateRenderer.renderVerifyEmail(verifyUrl);
         emailSender.send(request.email(), "[Concert] 이메일 인증을 완료해주세요", htmlBody);
     }
 
@@ -52,25 +53,6 @@ public class EmailService {
 
     private String generateVerifyUrl(String token) {
         return baseUrl + "/v1/email/verify?token=" + token;
-    }
-
-    private String buildHtml(String verifyUrl) {
-        return """
-                <div style="font-family: sans-serif; padding: 24px;">
-                  <h2>이메일 인증</h2>
-                  <p>아래 버튼을 눌러 이메일 인증을 완료해주세요. (30분간 유효)</p>
-                  <a href="%s"
-                     style="display:inline-block;padding:12px 24px;
-                            background:#4F46E5;color:#fff;
-                            text-decoration:none;border-radius:6px;">
-                    이메일 인증하기
-                  </a>
-                  <p style="color:#888;font-size:12px;margin-top:24px;">
-                    버튼이 동작하지 않으면 아래 링크를 복사해 주소창에 붙여넣어 주세요.<br/>
-                    %s
-                  </p>
-                </div>
-                """.formatted(verifyUrl, verifyUrl);
     }
 
     @Transactional
@@ -92,7 +74,7 @@ public class EmailService {
     }
 
     private void updateConsume(EmailVerifyToken emailVerifyToken) {
-        emailVerifyTokenRepository.updateConsumeAt(emailVerifyToken.getToken(), Status.ACTIVE);
+        emailVerifyTokenRepository.updateConsumeAt(emailVerifyToken.getId(), Status.ACTIVE);
         log.info("[EMAIL_VERIFY_TOKEN] consume update success. tokenId={}", emailVerifyToken.getId());
     }
 

--- a/src/main/java/com/ticket/concert/application/email/EmailService.java
+++ b/src/main/java/com/ticket/concert/application/email/EmailService.java
@@ -31,7 +31,6 @@ public class EmailService {
     private final EmailVerifyTokenRepository emailVerifyTokenRepository;
     private final EmailTemplateRenderer emailTemplateRenderer;
 
-    @Transactional
     public void sendEmail(MailSendRequest request) {
         String token = generateUUID();
         saveEmailVerifyToken(request.email(), token);

--- a/src/main/java/com/ticket/concert/application/email/EmailService.java
+++ b/src/main/java/com/ticket/concert/application/email/EmailService.java
@@ -1,0 +1,63 @@
+package com.ticket.concert.application.email;
+
+import com.ticket.concert.application.dto.mail.request.MailSendRequest;
+import com.ticket.concert.domain.email.EmailSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailService {
+
+    private static final Duration TOKEN_TTL = Duration.ofMinutes(30);
+    // 토큰 저장소
+
+    @Value("${app.base-url}")
+    private String baseUrl;
+
+    private final EmailSender emailSender;
+
+    public void sendEmail(MailSendRequest request) {
+        String token = generateUUID();
+        // 토큰 저장소에 저장
+        // tokenRepository.save(token, email, TOKEN_TTL);
+
+        String verifyUrl = generateVerifyUrl(token);
+        String htmlBody = buildHtml(verifyUrl);
+        emailSender.send(request.email(), "[Concert] 이메일 인증을 완료해주세요", htmlBody);
+    }
+
+    private String generateUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String generateVerifyUrl(String token) {
+        return baseUrl + "/v1/email/verify?token=" + token;
+    }
+
+    private String buildHtml(String verifyUrl) {
+        return """
+                <div style="font-family: sans-serif; padding: 24px;">
+                  <h2>이메일 인증</h2>
+                  <p>아래 버튼을 눌러 이메일 인증을 완료해주세요. (30분간 유효)</p>
+                  <a href="%s"
+                     style="display:inline-block;padding:12px 24px;
+                            background:#4F46E5;color:#fff;
+                            text-decoration:none;border-radius:6px;">
+                    이메일 인증하기
+                  </a>
+                  <p style="color:#888;font-size:12px;margin-top:24px;">
+                    버튼이 동작하지 않으면 아래 링크를 복사해 주소창에 붙여넣어 주세요.<br/>
+                    %s
+                  </p>
+                </div>
+                """.formatted(verifyUrl, verifyUrl);
+    }
+
+}

--- a/src/main/java/com/ticket/concert/application/email/EmailTemplateLoader.java
+++ b/src/main/java/com/ticket/concert/application/email/EmailTemplateLoader.java
@@ -1,0 +1,42 @@
+package com.ticket.concert.application.email;
+
+import com.ticket.concert.global.exception.BusinessException;
+import com.ticket.concert.global.exception.constant.ErrorCode;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class EmailTemplateLoader {
+
+    private static final String VERIFY_TEMPLATE_PATH = "templates/email/verify.html";
+
+    private String verifyTemplate;
+
+    @PostConstruct
+    public void init() {
+        this.verifyTemplate = load(VERIFY_TEMPLATE_PATH);
+        log.info("[EMAIL_TEMPLATE] loaded. path={}", VERIFY_TEMPLATE_PATH);
+    }
+
+    public String getVerifyTemplate() {
+        return verifyTemplate;
+    }
+
+    private String load(String path) {
+        ClassPathResource resource = new ClassPathResource(path);
+        try (InputStream is = resource.getInputStream()) {
+            return StreamUtils.copyToString(is, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("[EMAIL_TEMPLATE] load failed. path={}", path, e);
+            throw new BusinessException(ErrorCode.MAIL_TEMPLATE_LOAD_FAILED, e);
+        }
+    }
+}

--- a/src/main/java/com/ticket/concert/application/email/EmailTemplateRenderer.java
+++ b/src/main/java/com/ticket/concert/application/email/EmailTemplateRenderer.java
@@ -1,0 +1,17 @@
+package com.ticket.concert.application.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailTemplateRenderer {
+
+    private final EmailTemplateLoader templateLoader;
+
+    public String renderVerifyEmail(String verifyUrl) {
+        return templateLoader.getVerifyTemplate()
+                .replace("${verifyUrl}", verifyUrl);
+    }
+
+}

--- a/src/main/java/com/ticket/concert/application/user/UserService.java
+++ b/src/main/java/com/ticket/concert/application/user/UserService.java
@@ -1,4 +1,4 @@
-package com.ticket.concert.application;
+package com.ticket.concert.application.user;
 
 import com.ticket.concert.domain.user.User;
 import com.ticket.concert.application.dto.user.request.JoinRequest;

--- a/src/main/java/com/ticket/concert/domain/email/EmailSender.java
+++ b/src/main/java/com/ticket/concert/domain/email/EmailSender.java
@@ -1,0 +1,5 @@
+package com.ticket.concert.domain.email;
+
+public interface EmailSender {
+    void send(String mail, String content, String htmlBody);
+}

--- a/src/main/java/com/ticket/concert/domain/email/EmailVerifyToken.java
+++ b/src/main/java/com/ticket/concert/domain/email/EmailVerifyToken.java
@@ -3,13 +3,11 @@ package com.ticket.concert.domain.email;
 import com.ticket.concert.domain.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class EmailVerifyToken extends BaseEntity {
 
     private Long id;

--- a/src/main/java/com/ticket/concert/domain/email/EmailVerifyToken.java
+++ b/src/main/java/com/ticket/concert/domain/email/EmailVerifyToken.java
@@ -1,0 +1,25 @@
+package com.ticket.concert.domain.email;
+
+import com.ticket.concert.domain.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailVerifyToken extends BaseEntity {
+
+    private Long id;
+    private String token;
+    private String email;
+    private LocalDateTime expiresAt;
+    private LocalDateTime consumeAt;
+
+    public boolean isConsumable() {
+        return consumeAt == null && expiresAt.isAfter(LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/com/ticket/concert/domain/email/EmailVerifyTokenRepository.java
+++ b/src/main/java/com/ticket/concert/domain/email/EmailVerifyTokenRepository.java
@@ -1,0 +1,13 @@
+package com.ticket.concert.domain.email;
+
+import com.ticket.concert.domain.constant.Status;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailVerifyTokenRepository {
+    Long save(String token,  String email, LocalDateTime tokenTtl);
+    Optional<EmailVerifyToken> findByTokenAndStatus(String token, Status status);
+    void updateConsumeAt(String token, Status status);
+
+}

--- a/src/main/java/com/ticket/concert/domain/email/EmailVerifyTokenRepository.java
+++ b/src/main/java/com/ticket/concert/domain/email/EmailVerifyTokenRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 public interface EmailVerifyTokenRepository {
     Long save(String token,  String email, LocalDateTime tokenTtl);
     Optional<EmailVerifyToken> findByTokenAndStatus(String token, Status status);
-    void updateConsumeAt(String token, Status status);
+    void updateConsumeAt(Long id, Status status);
 
 }

--- a/src/main/java/com/ticket/concert/global/auth/filter/AuthorizationFilter.java
+++ b/src/main/java/com/ticket/concert/global/auth/filter/AuthorizationFilter.java
@@ -16,6 +16,8 @@ public class AuthorizationFilter extends OncePerRequestFilter {
     private static final List<String> EXCLUDE_PATHS = List.of(
             "/v1/auth/login",
             "/v1/user/join",
+            "/v1/email/send",
+            "/v1/email/verify",
             "/error"
     );
 

--- a/src/main/java/com/ticket/concert/global/config/RetryConfig.java
+++ b/src/main/java/com/ticket/concert/global/config/RetryConfig.java
@@ -3,6 +3,13 @@ package com.ticket.concert.global.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
 
+/**
+ * [@EnableRetry]
+ * - Spring Retry 기능을 활성화. 내부적으로 RetryConfiguration을 import해 @Retryable 메서드를
+ *   AOP 프록시로 감싸고, 재시도, 백오프, @Recover 흐름을 동작시킨다.
+ * - @Configuration를 통해 해당 클래스를 설정 클래스로 등록해, @EnableRetry가 스프링 컨테이너
+ *   기동 시점에 실제로 처리되도록 보장한다.
+ */
 @EnableRetry
 @Configuration
 public class RetryConfig {

--- a/src/main/java/com/ticket/concert/global/config/RetryConfig.java
+++ b/src/main/java/com/ticket/concert/global/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.ticket.concert.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+}

--- a/src/main/java/com/ticket/concert/global/exception/RetryEmailException.java
+++ b/src/main/java/com/ticket/concert/global/exception/RetryEmailException.java
@@ -1,0 +1,7 @@
+package com.ticket.concert.global.exception;
+
+public class RetryEmailException extends RuntimeException {
+    public RetryEmailException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
+++ b/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
@@ -32,7 +32,8 @@ public enum ErrorCode {
     MAIL_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E004", "메일 서비스가 일시적으로 불가합니다"),
     MAIL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E005", "메일 발송 중 오류가 발생했습니다"),
     EMAIL_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "E006", "잘못된 이메일 토큰입니다."),
-    EMAIL_TOKEN_NOT_USABLE(HttpStatus.BAD_REQUEST, "E007", "사용할 수 없는 이메일 토큰입니다.");
+    EMAIL_TOKEN_NOT_USABLE(HttpStatus.BAD_REQUEST, "E007", "사용할 수 없는 이메일 토큰입니다."),
+    MAIL_TEMPLATE_LOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E008", "메일 템플릿을 불러오지 못했습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
+++ b/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
@@ -23,7 +23,14 @@ public enum ErrorCode {
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "M002", "비밀번호 규칙에 맞지 않습니다."),
     INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "M003", "아이디 또는 비밀번호가 올바르지 않습니다."),
     EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "M004", "이미 사용중인 이메일입니다."),
-    PHONE_DUPLICATED(HttpStatus.BAD_REQUEST, "M005", "이미 사용중인 연락처입니다.");
+    PHONE_DUPLICATED(HttpStatus.BAD_REQUEST, "M005", "이미 사용중인 연락처입니다."),
+
+    // Email
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "E001", "잘못된 이메일 주소입니다."),
+    MAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E002", "메일 발송에 실패했습니다."),
+    INVALID_RECIPIENT(HttpStatus.BAD_REQUEST, "E003", "존재하지 않는 메일 주소입니다"),
+    MAIL_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E004", "메일 서비스가 일시적으로 불가합니다"),
+    MAIL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E005", "메일 발송 중 오류가 발생했습니다");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
+++ b/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
@@ -30,7 +30,9 @@ public enum ErrorCode {
     MAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E002", "메일 발송에 실패했습니다."),
     INVALID_RECIPIENT(HttpStatus.BAD_REQUEST, "E003", "존재하지 않는 메일 주소입니다"),
     MAIL_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "E004", "메일 서비스가 일시적으로 불가합니다"),
-    MAIL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E005", "메일 발송 중 오류가 발생했습니다");
+    MAIL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E005", "메일 발송 중 오류가 발생했습니다"),
+    EMAIL_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "E006", "잘못된 이메일 토큰입니다."),
+    EMAIL_TOKEN_NOT_USABLE(HttpStatus.BAD_REQUEST, "E007", "사용할 수 없는 이메일 토큰입니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
+++ b/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
@@ -40,17 +40,15 @@ public class SmtpEmailSender implements EmailSender {
             generateHelper(to, content, htmlBody, message);
             javaMailSender.send(message);
             log.info("[EMAIL SEND] success.");
-
         } catch (MailAuthenticationException e) {
             log.error("[EMAIL SEND] SMTP 인증 실패, SMTP 설정 확인 필요. ");
-            throw new BusinessException(ErrorCode.MAIL_SERVER_ERROR);
+            throw new BusinessException(ErrorCode.MAIL_SERVER_ERROR, e);
         } catch (MailSendException e) {
             handleMailSendException(e, to);
         } catch (MailException e) {
-            log.error("[EMAIL SEND] 메일 처리 실패. to={}", to);
+            log.error("[EMAIL SEND] 메일 처리 실패. to={}", to, e);
             throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
         }
-
     }
 
     private void generateHelper(String to, String content, String htmlBody, MimeMessage message) {
@@ -61,10 +59,10 @@ public class SmtpEmailSender implements EmailSender {
             helper.setSubject(content);
             helper.setText(htmlBody, true);
         } catch (AddressException e) {
-            log.warn("INVALID EMAIL. to={}", to);
+            log.warn("INVALID EMAIL. to={}", to, e);
             throw new BusinessException(ErrorCode.INVALID_EMAIL);
         } catch (MessagingException e) {
-            log.error("MAIL SEND FAILED. to={}", to);
+            log.error("MAIL SEND FAILED. to={}", to, e);
             throw new BusinessException(ErrorCode.MAIL_SEND_FAILED);
         }
     }

--- a/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
+++ b/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
@@ -37,6 +37,14 @@ public class SmtpEmailSender implements EmailSender {
     @Value("${mail.from}")
     private String from;
 
+    /**
+     * [@Retryable 내부 동작 방식]
+     * 먼저 @EnableRetry가 등록한 인터셉터가 @Retry 메서드를 가진 빈 프록시로 감싸고,
+     * 외부에서 메서드를 호출하면 실제 메서드 대신 프록시가 먼저 가로채 재시도 로직을 실행합니다.
+     * - 재시도 트리거 : 메서드 실행 중 retry 속성에 지정한 예외가 던져질 때만 재시도합니다.
+     * - 재시도 횟수 : maxAttempts = 3 옵션은 '재시도 3회'가 아니라 최초 호출 1회, 재시도 2회, 총 3회 실행을 의미합니다.
+     * - 백오프 대기 : 실패 후 다음 시도까지 @Backoff 정책만큼 대시합니다. 이 대기는 호출 스레드를 Thread.sleep으로 블로킹합니다.
+     */
     @Retryable(
             retryFor = RetryEmailException.class,
             maxAttempts = 3,
@@ -117,6 +125,11 @@ public class SmtpEmailSender implements EmailSender {
         throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
     }
 
+    /**
+     * @Retryable의 모든 시도가 소진되면 마지막에 발생한 예외 타입과 메서드 파라미터 시그니처가 일치하는
+     * @Recover 메서드를 자동으로 찾아 호출합니다. @Recover의 파라미터는(발생 예외, 원본 메서드 파라미터..) 순서로
+     * 매칭되어야 하고, 반환 타입도 원본 메서드와 호환되어야 합니다.
+     */
     @Recover
     public void recover(RetryEmailException e, String to, String content, String htmlBody) {
         log.error("[EMAIL SEND] 재시도 모두 실패. to={}", to, e);

--- a/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
+++ b/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
@@ -2,6 +2,7 @@ package com.ticket.concert.infrastructure.mail;
 
 import com.ticket.concert.domain.email.EmailSender;
 import com.ticket.concert.global.exception.BusinessException;
+import com.ticket.concert.global.exception.RetryEmailException;
 import com.ticket.concert.global.exception.constant.ErrorCode;
 import jakarta.mail.Address;
 import jakarta.mail.MessagingException;
@@ -18,6 +19,9 @@ import org.springframework.mail.MailException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 import java.net.ConnectException;
@@ -33,6 +37,11 @@ public class SmtpEmailSender implements EmailSender {
     @Value("${mail.from}")
     private String from;
 
+    @Retryable(
+            retryFor = RetryEmailException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000)
+    )
     @Override
     public void send(String to, String content, String htmlBody) {
         try {
@@ -60,10 +69,10 @@ public class SmtpEmailSender implements EmailSender {
             helper.setText(htmlBody, true);
         } catch (AddressException e) {
             log.warn("INVALID EMAIL. to={}", to, e);
-            throw new BusinessException(ErrorCode.INVALID_EMAIL);
+            throw new BusinessException(ErrorCode.INVALID_EMAIL, e);
         } catch (MessagingException e) {
             log.error("MAIL SEND FAILED. to={}", to, e);
-            throw new BusinessException(ErrorCode.MAIL_SEND_FAILED);
+            throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
         }
     }
 
@@ -86,7 +95,7 @@ public class SmtpEmailSender implements EmailSender {
                 throw new BusinessException(ErrorCode.MAIL_SERVER_ERROR, e);
             }
             if (returnCode >= 400 && returnCode < 500) { // 일시 실패
-                throw new BusinessException(ErrorCode.MAIL_SERVER_UNAVAILABLE, e);
+                throw new RetryEmailException(e);
             }
 
             throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
@@ -94,11 +103,23 @@ public class SmtpEmailSender implements EmailSender {
 
         if (cause instanceof SendFailedException sendEx) {
             Address[] invalid = sendEx.getInvalidAddresses();
+            Address[] validUnsent = sendEx.getValidUnsentAddresses();
+
             log.warn("[EMAIL SEND] 일부 수신자 거부. invalid={}", Arrays.toString(invalid));
+
+            if (validUnsent != null && validUnsent.length > 0) {
+                throw new RetryEmailException(e);
+            }
             throw new BusinessException(ErrorCode.INVALID_RECIPIENT, e);
         }
 
         log.error("[EMAIL SEND] 메일 전송 실패. to={}", to, e);
         throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
+    }
+
+    @Recover
+    public void recover(RetryEmailException e, String to, String content, String htmlBody) {
+        log.error("[EMAIL SEND] 재시도 모두 실패. to={}", to, e);
+        throw new BusinessException(ErrorCode.MAIL_SERVER_UNAVAILABLE, e);
     }
 }

--- a/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
+++ b/src/main/java/com/ticket/concert/infrastructure/mail/SmtpEmailSender.java
@@ -1,0 +1,106 @@
+package com.ticket.concert.infrastructure.mail;
+
+import com.ticket.concert.domain.email.EmailSender;
+import com.ticket.concert.global.exception.BusinessException;
+import com.ticket.concert.global.exception.constant.ErrorCode;
+import jakarta.mail.Address;
+import jakarta.mail.MessagingException;
+import jakarta.mail.SendFailedException;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.angus.mail.smtp.SMTPSendFailedException;
+import org.eclipse.angus.mail.util.MailConnectException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import java.net.ConnectException;
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    @Value("${mail.from}")
+    private String from;
+
+    @Override
+    public void send(String to, String content, String htmlBody) {
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            generateHelper(to, content, htmlBody, message);
+            javaMailSender.send(message);
+            log.info("[EMAIL SEND] success.");
+
+        } catch (MailAuthenticationException e) {
+            log.error("[EMAIL SEND] SMTP 인증 실패, SMTP 설정 확인 필요. ");
+            throw new BusinessException(ErrorCode.MAIL_SERVER_ERROR);
+        } catch (MailSendException e) {
+            handleMailSendException(e, to);
+        } catch (MailException e) {
+            log.error("[EMAIL SEND] 메일 처리 실패. to={}", to);
+            throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
+        }
+
+    }
+
+    private void generateHelper(String to, String content, String htmlBody, MimeMessage message) {
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setFrom(from);
+            helper.setTo(to);
+            helper.setSubject(content);
+            helper.setText(htmlBody, true);
+        } catch (AddressException e) {
+            log.warn("INVALID EMAIL. to={}", to);
+            throw new BusinessException(ErrorCode.INVALID_EMAIL);
+        } catch (MessagingException e) {
+            log.error("MAIL SEND FAILED. to={}", to);
+            throw new BusinessException(ErrorCode.MAIL_SEND_FAILED);
+        }
+    }
+
+    private void handleMailSendException(MailSendException e, String to) {
+        Throwable cause = e.getCause();
+
+        if (cause instanceof MailConnectException || cause instanceof ConnectException) {
+            log.error("[EMAIL SEND] 메일 서버 연결 실패. to={}", to, e);
+            throw new BusinessException(ErrorCode.MAIL_SERVER_UNAVAILABLE, e);
+        }
+
+        if (cause instanceof SMTPSendFailedException smtpEx) {
+            int returnCode = smtpEx.getReturnCode();
+            log.warn("[EMAIL SEND] SMTP 거부. to={}, code={}, msg={}", to, returnCode, smtpEx.getMessage());
+
+            if (returnCode == 550 || returnCode == 553) { // 영구 실패
+                throw new BusinessException(ErrorCode.INVALID_RECIPIENT, e);
+            }
+            if (returnCode == 535) {
+                throw new BusinessException(ErrorCode.MAIL_SERVER_ERROR, e);
+            }
+            if (returnCode >= 400 && returnCode < 500) { // 일시 실패
+                throw new BusinessException(ErrorCode.MAIL_SERVER_UNAVAILABLE, e);
+            }
+
+            throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
+        }
+
+        if (cause instanceof SendFailedException sendEx) {
+            Address[] invalid = sendEx.getInvalidAddresses();
+            log.warn("[EMAIL SEND] 일부 수신자 거부. invalid={}", Arrays.toString(invalid));
+            throw new BusinessException(ErrorCode.INVALID_RECIPIENT, e);
+        }
+
+        log.error("[EMAIL SEND] 메일 전송 실패. to={}", to, e);
+        throw new BusinessException(ErrorCode.MAIL_SEND_FAILED, e);
+    }
+}

--- a/src/main/java/com/ticket/concert/infrastructure/persistence/email/JdbcEmailVerifyTokenRepository.java
+++ b/src/main/java/com/ticket/concert/infrastructure/persistence/email/JdbcEmailVerifyTokenRepository.java
@@ -1,0 +1,82 @@
+package com.ticket.concert.infrastructure.persistence.email;
+
+import com.ticket.concert.domain.constant.Status;
+import com.ticket.concert.domain.email.EmailVerifyToken;
+import com.ticket.concert.domain.email.EmailVerifyTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcEmailVerifyTokenRepository implements EmailVerifyTokenRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public static final RowMapper<EmailVerifyToken> EMAIL_VERIFY_TOKEN_ROW_MAPPER = (rs, rowNum) -> new EmailVerifyToken(
+            rs.getLong("id"),
+            rs.getString("token"),
+            rs.getString("email"),
+            rs.getObject("expires_at", LocalDateTime.class),
+            rs.getObject("consume_at", LocalDateTime.class)
+    );
+
+    @Override
+    public Long save(String token, String email, LocalDateTime expiresAt) {
+        String sql = """
+                INSERT INTO email_verify_token (token, email, expires_at)
+                VALUES (:token, :email, :expiresAt)
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("token", token)
+                .addValue("email", email)
+                .addValue("expiresAt", expiresAt);
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(sql, params, keyHolder, new String[]{"id"});
+
+        return Objects.requireNonNull(keyHolder.getKey()).longValue();
+    }
+
+    @Override
+    public Optional<EmailVerifyToken> findByTokenAndStatus(String token, Status status) {
+        String sql = """
+                SELECT id, token, email, expires_at, consume_at
+                FROM email_verify_token
+                WHERE token = :token AND status = :status
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("token", token)
+                .addValue("status", status.name());
+
+        List<EmailVerifyToken> emailVerifyTokens = jdbcTemplate.query(sql, params, EMAIL_VERIFY_TOKEN_ROW_MAPPER);
+        return Optional.ofNullable(DataAccessUtils.singleResult(emailVerifyTokens));
+    }
+
+    @Override
+    public void updateConsumeAt(String token, Status status) {
+        String sql = """
+                UPDATE email_verify_token
+                SET consume_at = NOW()
+                WHERE token = :token AND status = :status
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("token", token)
+                .addValue("status", status.name());
+
+        jdbcTemplate.update(sql, params);
+    }
+}

--- a/src/main/java/com/ticket/concert/infrastructure/persistence/email/JdbcEmailVerifyTokenRepository.java
+++ b/src/main/java/com/ticket/concert/infrastructure/persistence/email/JdbcEmailVerifyTokenRepository.java
@@ -66,15 +66,15 @@ public class JdbcEmailVerifyTokenRepository implements EmailVerifyTokenRepositor
     }
 
     @Override
-    public void updateConsumeAt(String token, Status status) {
+    public void updateConsumeAt(Long id, Status status) {
         String sql = """
                 UPDATE email_verify_token
                 SET consume_at = NOW()
-                WHERE token = :token AND status = :status
+                WHERE id = :id AND status = :status
                 """;
 
         MapSqlParameterSource params = new MapSqlParameterSource()
-                .addValue("token", token)
+                .addValue("id", id)
                 .addValue("status", status.name());
 
         jdbcTemplate.update(sql, params);

--- a/src/main/java/com/ticket/concert/presentation/AuthController.java
+++ b/src/main/java/com/ticket/concert/presentation/AuthController.java
@@ -3,7 +3,7 @@ package com.ticket.concert.presentation;
 import com.ticket.concert.application.dto.auth.request.LoginRequest;
 import com.ticket.concert.application.dto.auth.response.LoginResponse;
 import com.ticket.concert.global.common.ApiResponse;
-import com.ticket.concert.application.AuthService;
+import com.ticket.concert.application.auth.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ticket/concert/presentation/EmailController.java
+++ b/src/main/java/com/ticket/concert/presentation/EmailController.java
@@ -1,8 +1,8 @@
 package com.ticket.concert.presentation;
 
-import com.ticket.concert.application.dto.user.request.JoinRequest;
+import com.ticket.concert.application.dto.mail.request.MailSendRequest;
+import com.ticket.concert.application.email.EmailService;
 import com.ticket.concert.global.common.ApiResponse;
-import com.ticket.concert.application.user.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-public class UserController {
+public class EmailController {
 
-    private final UserService userService;
+    private final EmailService emailService;
 
-    @PostMapping(value = "/v1/user/join")
-    public ApiResponse<Void> join(@Valid @RequestBody JoinRequest request) {
-        userService.join(request);
+    @PostMapping(value = "/v1/email/send")
+    public ApiResponse<Void> sendEmail(@Valid @RequestBody MailSendRequest request) {
+        emailService.sendEmail(request);
         return ApiResponse.success();
     }
 }

--- a/src/main/java/com/ticket/concert/presentation/EmailController.java
+++ b/src/main/java/com/ticket/concert/presentation/EmailController.java
@@ -6,8 +6,10 @@ import com.ticket.concert.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,6 +22,12 @@ public class EmailController {
     @PostMapping(value = "/v1/email/send")
     public ApiResponse<Void> sendEmail(@Valid @RequestBody MailSendRequest request) {
         emailService.sendEmail(request);
+        return ApiResponse.success();
+    }
+
+    @GetMapping(value = "/v1/email/verify")
+    public ApiResponse<Void> verityEmail(@RequestParam String token) {
+        emailService.verifyToken(token);
         return ApiResponse.success();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,17 @@ spring:
     username: root
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ohohuniverse12@gmail.com
+    password: password
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
+app:
+  base-url: http://localhost:10101
+
+mail:
+  from: ohuniverse@gmail.com

--- a/src/main/resources/templates/email/verify.html
+++ b/src/main/resources/templates/email/verify.html
@@ -1,0 +1,14 @@
+<div style="font-family: sans-serif; padding: 24px;">
+    <h2>이메일 인증</h2>
+    <p>아래 버튼을 눌러 이메일 인증을 완료해주세요. (30분간 유효)</p>
+    <a href="${verifyUrl}"
+       style="display:inline-block;padding:12px 24px;
+            background:#4F46E5;color:#fff;
+            text-decoration:none;border-radius:6px;">
+        이메일 인증하기
+    </a>
+    <p style="color:#888;font-size:12px;margin-top:24px;">
+        버튼이 동작하지 않으면 아래 링크를 복사해 주소창에 붙여넣어 주세요.<br/>
+        ${verifyUrl}
+    </p>
+</div>

--- a/src/test/java/com/ticket/concert/infrastructure/mail/SmtpEmailSenderTest.java
+++ b/src/test/java/com/ticket/concert/infrastructure/mail/SmtpEmailSenderTest.java
@@ -1,0 +1,114 @@
+package com.ticket.concert.infrastructure.mail;
+
+import com.ticket.concert.domain.email.EmailSender;
+import com.ticket.concert.global.exception.BusinessException;
+import jakarta.mail.Address;
+import jakarta.mail.SendFailedException;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@SpringJUnitConfig
+@TestPropertySource(properties = "mail.from=test@example.com")
+class SmtpEmailSenderTest {
+
+    /**
+     * Retry 테스트의 핵심. 전체 @SpringBootTest를 띄우지 않고, 재시도 검증에 필요한 최소한의 빈만 모아 구성
+     */
+    @Configuration
+    @EnableRetry
+    static class TestConfig {
+        /**
+         * 실제 SMTP 서버로 메일을 보내면 안 되니 JavaMailSender를 목으로 등록
+         */
+        @Bean
+        JavaMailSender javaMailSender() {
+            return mock(JavaMailSender.class);
+        }
+
+        /**
+         * 검증 대상 빈 위 목을 주입 받아 생성하면, @EnalbeRetry가 이 빈을 재시도 프록시로 감쌉니다.
+         */
+        @Bean
+        SmtpEmailSender smtpEmailSender(JavaMailSender javaMailSender) {
+            return new SmtpEmailSender(javaMailSender);
+        }
+
+        /**
+         * ${} 플레이스홀더를 실제ㅗ 치환해주는 빈입니다. static인 이유는 이 빈이 다른 빈들보다 먼저 생성돼야 하기 때문
+         */
+        @Bean
+        static PropertySourcesPlaceholderConfigurer placeholderConfigurer() {
+            return new PropertySourcesPlaceholderConfigurer();
+        }
+    }
+
+    // 프록시는 인터페이스 타입으로 주입받는다 (JDK 동적 프록시)
+    @Autowired
+    private EmailSender emailSender;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    /**
+     * 테스트 간 공유돼서 목 인스턴스가 재시용됩니다. .reset()으로 이전 테스트의 기록을 초기화해 테스트까지 간섭하지 않게합니다.
+     * send() 내부에서 JavaMailSender.createMimeMEssage()를 호출합니다. 목은 기본적으로 null을 반환하므로,
+     * 그대로 두면 MimeMessageHelper를 만들 때 NPE가 터져버립니다.
+     */
+    @BeforeEach
+    void setUp() {
+        reset(javaMailSender);
+        when(javaMailSender.createMimeMessage())
+                .thenReturn(new JavaMailSenderImpl().createMimeMessage());
+    }
+
+    /**
+     * 프로덕션 코드에서 재발송 로직이 발생하는 조건을 만족하는 예외
+     */
+    private MailSendException retryable() throws AddressException {
+        Address[] validUnsent = {new InternetAddress("unsent@example.com")};
+        SendFailedException sfe = new SendFailedException(
+                "temporary", new Exception(), new Address[0], validUnsent, new Address[0]);
+        return new MailSendException("send failed", sfe);
+    }
+
+    @Test
+    @DisplayName("재시도 대상 예외가 계속 발생하면 총 3회 시도 후 @Recover가 동작한다")
+    void retryExhaustedThenRecover() throws AddressException {
+        doThrow(retryable()).when(javaMailSender).send(any(MimeMessage.class));
+
+        assertThatThrownBy(() -> emailSender.send("to@example.com", "subject", "<p>body</p>"))
+                .isInstanceOf(BusinessException.class);
+
+        verify(javaMailSender, times(3)).send(any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("재시도 중간에 성공하면 이후 재시도는 일어나지 않는다")
+    void retryThenSuccess() throws AddressException {
+        doThrow(retryable())
+                .doNothing() // 2회차 성공
+                .when(javaMailSender).send(any(MimeMessage.class));
+
+        emailSender.send("to@example.com", "subject", "<p>body</p>");
+
+        verify(javaMailSender, times(2)).send(any(MimeMessage.class));
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 개요
- 인증 메일 발송 및 검증 기능을 개발했습니다. UUID 토큰을 메일 본문에 넣고, 사용자가 메일 내 `이메일 인증하기` 버튼을 클릭하면 토큰을 검증하는 흐름입니다.

## 🔗 관련 이슈
- Related to #13 

## 🛠️ 작업 내용

### 1. 이메일 발송 기능 개발
- [x] email_varify_token 테이블 생성
  - id, token, email, expires_at, consume_at, status 컬럼 구성
  - token 컬럼 유니크 제약조건 (중복 방지)
- [x] Token 발급을 위해 UUID 생성
- [x] 발송 실패 에러메시지 분기
  - `MailAuthenticationException` : SMTP 서버 인증 실패(계정/비밀번호 오류 등)
  - `SMTPSendFailedException` : SMTP 서버가 응답 코드로 거부
    - 550, 553 : 영구적인 실패(존재하지 않은 이메일 등)
    - 535 : SMTP 인증 실패 (클라이언트 인증 정보가 거부됨)
    - 400~500 : 일시적인 실패(일치 차단, 큐 포화 등)

### 2. 이메일 검증 기능 개발
- [x] Token 검증 조건  : `consume_at이 null`인 경우 그리고 `expires_at이 만료`되지 않은 경우

## 💬 비고
- 인메모리/DB/Redis 3가지 선택지 중 DB에서 관리
  ###  in-memory 
  - 가장 빠르고 별도 인프로 불필요
  - 애플리케이션 재시작 시 모든 토큰 유실
  - TTL 처리를 위해 별도의 스케줄러/만료 관리 로직 필요
  
  ### DB 
  - 재시작/배포에도 토큰 유호
  - 다중 인스턴스 환경에서 동일한 데이터 공유
  - 인메모리, Redis 대비 속도 느림
  
  ### Redis
  - TTL 지원
  - 인메모리 기반으로 빠름
  - 추가 인프라/운영 비용 발생

- 인증번호가 아닌 이메일 본문 '이메일 인증하기' 버튼 클릭 시 Token을 통해 검증 요청 진행