### PR TITLE
[Feat] 상품 좌석 조회 기능 개발

### DIFF
--- a/sql/table.sql
+++ b/sql/table.sql
@@ -59,7 +59,7 @@ CREATE TABLE `performance`
     `id`                 BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL COMMENT '고유번호',
     `product_id`         BIGINT                            NOT NULL COMMENT '상품 고유번호',
     `show_at`            DATETIME                          NOT NULL COMMENT '공연 일시',
-    `performance_status` VARCHAR(50)                       NOT NULL COMMENT '예매 상태(예매 가능 / 매진 / 취소)',
+    `status`             VARCHAR(50)                       NOT NULL COMMENT '예매 상태(예매 가능 / 매진 / 취소)',
     `created_at`         DATETIME                          NOT NULL DEFAULT NOW() COMMENT '생성일',
     `updated_at`         DATETIME                          NULL COMMENT '수정일',
     `deleted`            TINYINT(1)                        NOT NULL DEFAULT 0 COMMENT '삭제 여부'
@@ -83,11 +83,11 @@ CREATE TABLE `seat`
 CREATE TABLE `seat_inventory`
 (
     `id`               BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL COMMENT '고유번호',
-    `user_id`          BIGINT                            NOT NULL COMMENT '회원 고유번호',
+    `user_id`          BIGINT                            NULL COMMENT '회원 고유번호',
     `seat_id`          BIGINT                            NOT NULL COMMENT '좌석 고유번호',
     `performance_id`   BIGINT                            NOT NULL COMMENT '회차 고유번호',
-    `inventory_status` VARCHAR(50)                       NOT NULL COMMENT '좌석 상태(AVAILABLE/HELD/SOLD/BLOCKED)',
-    `held_until`       DATETIME                          NOT NULL COMMENT '선점(결제 중) 만료 시각)',
+    `status`           VARCHAR(50)                       NOT NULL COMMENT '좌석 상태(AVAILABLE/HELD/SOLD/BLOCKED)',
+    `held_until`       DATETIME                          NULL COMMENT '선점(결제 중) 만료 시각)',
     `created_at`       DATETIME                          NOT NULL DEFAULT NOW() COMMENT '생성일',
     `updated_at`       DATETIME                          NULL COMMENT '수정일',
     `deleted`          TINYINT(1)                        NOT NULL DEFAULT 0 COMMENT '삭제 여부'

--- a/src/main/java/com/ticket/concert/application/Performance/PerformanceService.java
+++ b/src/main/java/com/ticket/concert/application/Performance/PerformanceService.java
@@ -1,0 +1,25 @@
+package com.ticket.concert.application.Performance;
+
+import com.ticket.concert.application.dto.performance.response.PerformanceResponse;
+import com.ticket.concert.domain.performance.entity.Performance;
+import com.ticket.concert.domain.performance.repository.PerformanceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PerformanceService {
+
+    private final PerformanceRepository performanceRepository;
+
+    public List<PerformanceResponse> getPerformances(Long productId) {
+        List<Performance> performanceResponses = performanceRepository.findByProductIdAndDeleted(productId, false);
+        return performanceResponses.stream()
+                .map(PerformanceResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/ticket/concert/application/dto/performance/response/PerformanceResponse.java
+++ b/src/main/java/com/ticket/concert/application/dto/performance/response/PerformanceResponse.java
@@ -1,0 +1,19 @@
+package com.ticket.concert.application.dto.performance.response;
+
+import com.ticket.concert.domain.performance.entity.Performance;
+
+import java.time.LocalDateTime;
+
+public record PerformanceResponse(
+        Long id,
+        LocalDateTime showAt,
+        String status
+) {
+    public static PerformanceResponse from(Performance performance) {
+        return new PerformanceResponse(
+                performance.getId(),
+                performance.getShowAt(),
+                performance.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/ticket/concert/application/dto/seat/response/SeatResponse.java
+++ b/src/main/java/com/ticket/concert/application/dto/seat/response/SeatResponse.java
@@ -1,5 +1,7 @@
 package com.ticket.concert.application.dto.seat.response;
 
+import com.ticket.concert.domain.seat.entity.Seat;
+
 public record SeatResponse(
         Long id,
         String zone,
@@ -9,4 +11,15 @@ public record SeatResponse(
         String grade,
         String color
 ) {
+    public static SeatResponse from(Seat seat){
+        return new SeatResponse(
+                seat.getId(),
+                seat.getZone(),
+                seat.getRow(),
+                seat.getSeatNo(),
+                seat.getPrice(),
+                seat.getGrade(),
+                seat.getColor()
+        );
+    }
 }

--- a/src/main/java/com/ticket/concert/application/dto/seat/response/SeatResponse.java
+++ b/src/main/java/com/ticket/concert/application/dto/seat/response/SeatResponse.java
@@ -1,0 +1,12 @@
+package com.ticket.concert.application.dto.seat.response;
+
+public record SeatResponse(
+        Long id,
+        String zone,
+        String row,
+        String seatNo,
+        Integer price,
+        String grade,
+        String color
+) {
+}

--- a/src/main/java/com/ticket/concert/application/dto/seatInventory/request/SeatInventoryRequest.java
+++ b/src/main/java/com/ticket/concert/application/dto/seatInventory/request/SeatInventoryRequest.java
@@ -1,0 +1,9 @@
+package com.ticket.concert.application.dto.seatInventory.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SeatInventoryRequest(
+        @NotNull(message = "회차 고유번호는 필수입니다.")
+        Long performanceId
+) {
+}

--- a/src/main/java/com/ticket/concert/application/dto/seatInventory/response/SeatInventoryResponse.java
+++ b/src/main/java/com/ticket/concert/application/dto/seatInventory/response/SeatInventoryResponse.java
@@ -1,0 +1,20 @@
+package com.ticket.concert.application.dto.seatInventory.response;
+
+import com.ticket.concert.domain.saetInventory.entity.Status;
+
+import java.time.LocalDateTime;
+
+public record SeatInventoryResponse(
+        Long id,
+        Long seatId,
+        Long performanceId,
+        Status status,
+        LocalDateTime heldUntil,
+        String zone,
+        String row,
+        String seatNo,
+        String grade,
+        Integer price
+) {
+
+}

--- a/src/main/java/com/ticket/concert/application/dto/seatInventory/response/SeatInventoryResponse.java
+++ b/src/main/java/com/ticket/concert/application/dto/seatInventory/response/SeatInventoryResponse.java
@@ -1,6 +1,6 @@
 package com.ticket.concert.application.dto.seatInventory.response;
 
-import com.ticket.concert.domain.saetInventory.entity.Status;
+import com.ticket.concert.domain.saetInventory.entity.SeatInventoryStatus;
 
 import java.time.LocalDateTime;
 
@@ -8,13 +8,8 @@ public record SeatInventoryResponse(
         Long id,
         Long seatId,
         Long performanceId,
-        Status status,
-        LocalDateTime heldUntil,
-        String zone,
-        String row,
-        String seatNo,
-        String grade,
-        Integer price
+        SeatInventoryStatus status,
+        LocalDateTime heldUntil
 ) {
 
 }

--- a/src/main/java/com/ticket/concert/application/seat/SeatService.java
+++ b/src/main/java/com/ticket/concert/application/seat/SeatService.java
@@ -1,0 +1,21 @@
+package com.ticket.concert.application.seat;
+
+import com.ticket.concert.application.dto.seat.response.SeatResponse;
+import com.ticket.concert.domain.seat.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+
+    public List<SeatResponse> getSeats(Long productId) {
+        return null;
+    }
+}

--- a/src/main/java/com/ticket/concert/application/seat/SeatService.java
+++ b/src/main/java/com/ticket/concert/application/seat/SeatService.java
@@ -1,6 +1,7 @@
 package com.ticket.concert.application.seat;
 
 import com.ticket.concert.application.dto.seat.response.SeatResponse;
+import com.ticket.concert.domain.seat.entity.Seat;
 import com.ticket.concert.domain.seat.repository.SeatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,9 @@ public class SeatService {
     private final SeatRepository seatRepository;
 
     public List<SeatResponse> getSeats(Long productId) {
-        return null;
+        List<Seat> seats = seatRepository.findByProductIdAndDeleted(productId, false);
+        return seats.stream()
+                .map(SeatResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/ticket/concert/application/seatInventory/SeatInventoryService.java
+++ b/src/main/java/com/ticket/concert/application/seatInventory/SeatInventoryService.java
@@ -1,0 +1,22 @@
+package com.ticket.concert.application.seatInventory;
+
+import com.ticket.concert.application.dto.seatInventory.request.SeatInventoryRequest;
+import com.ticket.concert.application.dto.seatInventory.response.SeatInventoryResponse;
+import com.ticket.concert.domain.saetInventory.repository.SeatInventoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SeatInventoryService {
+
+    private final SeatInventoryRepository seatInventoryRepository;
+
+    public List<SeatInventoryResponse> getSeatInventory(SeatInventoryRequest request) {
+        return seatInventoryRepository.findBySeatIdAndPerformanceIdAndDeleted(request.performanceId(), false);
+    }
+}

--- a/src/main/java/com/ticket/concert/domain/performance/entity/Performance.java
+++ b/src/main/java/com/ticket/concert/domain/performance/entity/Performance.java
@@ -33,7 +33,7 @@ public class Performance {
     private LocalDateTime showAt;
 
     @Enumerated(value = EnumType.STRING)
-    private Status status;
+    private PerformanceStatus status;
 
     private Boolean deleted;
 }

--- a/src/main/java/com/ticket/concert/domain/performance/entity/Performance.java
+++ b/src/main/java/com/ticket/concert/domain/performance/entity/Performance.java
@@ -1,0 +1,39 @@
+package com.ticket.concert.domain.performance.entity;
+
+import com.ticket.concert.domain.product.entity.Product;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Table(name = "performance")
+public class Performance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private LocalDateTime showAt;
+
+    @Enumerated(value = EnumType.STRING)
+    private Status status;
+
+    private Boolean deleted;
+}

--- a/src/main/java/com/ticket/concert/domain/performance/entity/PerformanceStatus.java
+++ b/src/main/java/com/ticket/concert/domain/performance/entity/PerformanceStatus.java
@@ -3,14 +3,14 @@ package com.ticket.concert.domain.performance.entity;
 import lombok.Getter;
 
 @Getter
-public enum Status {
+public enum PerformanceStatus {
     AVAILABLE("예매 가능"),
     SOLD_OUT("매진"),
     CANCELED("취소");
 
     private final String description;
 
-    Status(String description) {
+    PerformanceStatus(String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/ticket/concert/domain/performance/entity/Status.java
+++ b/src/main/java/com/ticket/concert/domain/performance/entity/Status.java
@@ -1,0 +1,16 @@
+package com.ticket.concert.domain.performance.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Status {
+    AVAILABLE("예매 가능"),
+    SOLD_OUT("매진"),
+    CANCELED("취소");
+
+    private final String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/ticket/concert/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/ticket/concert/domain/performance/repository/PerformanceRepository.java
@@ -1,0 +1,10 @@
+package com.ticket.concert.domain.performance.repository;
+
+import com.ticket.concert.domain.performance.entity.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+    List<Performance> findByProductIdAndDeleted(Long productId, Boolean deleted);
+}

--- a/src/main/java/com/ticket/concert/domain/saetInventory/entity/SeatInventory.java
+++ b/src/main/java/com/ticket/concert/domain/saetInventory/entity/SeatInventory.java
@@ -1,0 +1,50 @@
+package com.ticket.concert.domain.saetInventory.entity;
+
+import com.ticket.concert.domain.BaseTimeEntity;
+import com.ticket.concert.domain.performance.entity.Performance;
+import com.ticket.concert.domain.seat.entity.Seat;
+import com.ticket.concert.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Table(name = "seat_inventory")
+public class SeatInventory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id")
+    private Seat seat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id")
+    private Performance performance;
+
+    @Enumerated(value = EnumType.STRING)
+    private Status status;
+
+    private LocalDateTime heldUntil;
+
+    private Boolean deleted;
+}

--- a/src/main/java/com/ticket/concert/domain/saetInventory/entity/SeatInventory.java
+++ b/src/main/java/com/ticket/concert/domain/saetInventory/entity/SeatInventory.java
@@ -42,7 +42,7 @@ public class SeatInventory extends BaseTimeEntity {
     private Performance performance;
 
     @Enumerated(value = EnumType.STRING)
-    private Status status;
+    private SeatInventoryStatus status;
 
     private LocalDateTime heldUntil;
 

--- a/src/main/java/com/ticket/concert/domain/saetInventory/entity/SeatInventoryStatus.java
+++ b/src/main/java/com/ticket/concert/domain/saetInventory/entity/SeatInventoryStatus.java
@@ -3,15 +3,15 @@ package com.ticket.concert.domain.saetInventory.entity;
 import lombok.Getter;
 
 @Getter
-public enum Status {
+public enum SeatInventoryStatus {
     AVAILABLE("예매 가능"),
-    HELD("결제 대기"),
+    HELD("선점중"),
     SOLD("판매 완료"),
     BLOCKED("판매 불가");
 
     private final String description;
 
-    Status(String description) {
+    SeatInventoryStatus(String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/ticket/concert/domain/saetInventory/entity/Status.java
+++ b/src/main/java/com/ticket/concert/domain/saetInventory/entity/Status.java
@@ -1,0 +1,17 @@
+package com.ticket.concert.domain.saetInventory.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Status {
+    AVAILABLE("예매 가능"),
+    HELD("결제 대기"),
+    SOLD("판매 완료"),
+    BLOCKED("판매 불가");
+
+    private final String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/ticket/concert/domain/saetInventory/repository/SeatInventoryRepository.java
+++ b/src/main/java/com/ticket/concert/domain/saetInventory/repository/SeatInventoryRepository.java
@@ -11,8 +11,7 @@ import java.util.List;
 public interface SeatInventoryRepository extends JpaRepository<SeatInventory, Long> {
     @Query("""
             SELECT new com.ticket.concert.application.dto.seatInventory.response.SeatInventoryResponse(
-                   si.id, s.id, si.performance.id, si.status, si.heldUntil,
-                   s.zone, s.row, s.seatNo, s.grade, s.price)
+                   si.id, s.id, si.performance.id, si.status, si.heldUntil)
             FROM SeatInventory si
                 JOIN si.seat s
             WHERE si.performance.id = :performanceId

--- a/src/main/java/com/ticket/concert/domain/saetInventory/repository/SeatInventoryRepository.java
+++ b/src/main/java/com/ticket/concert/domain/saetInventory/repository/SeatInventoryRepository.java
@@ -1,0 +1,22 @@
+package com.ticket.concert.domain.saetInventory.repository;
+
+import com.ticket.concert.application.dto.seatInventory.response.SeatInventoryResponse;
+import com.ticket.concert.domain.saetInventory.entity.SeatInventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+
+public interface SeatInventoryRepository extends JpaRepository<SeatInventory, Long> {
+    @Query("""
+            SELECT new com.ticket.concert.application.dto.seatInventory.response.SeatInventoryResponse(
+                   si.id, s.id, si.performance.id, si.status, si.heldUntil,
+                   s.zone, s.row, s.seatNo, s.grade, s.price)
+            FROM SeatInventory si
+                JOIN si.seat s
+            WHERE si.performance.id = :performanceId
+              AND si.deleted = :deleted
+            """)
+    List<SeatInventoryResponse> findBySeatIdAndPerformanceIdAndDeleted(Long performanceId, Boolean deleted);
+}

--- a/src/main/java/com/ticket/concert/domain/seat/entity/Seat.java
+++ b/src/main/java/com/ticket/concert/domain/seat/entity/Seat.java
@@ -1,0 +1,36 @@
+package com.ticket.concert.domain.seat.entity;
+
+import com.ticket.concert.domain.BaseTimeEntity;
+import com.ticket.concert.domain.product.entity.Product;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Table(name = "seat")
+public class Seat extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+    private String zone;
+    private String row;
+    private String seatNo;
+    private String grade;
+    private Integer price;
+    private String color;
+    private Boolean deleted;
+}

--- a/src/main/java/com/ticket/concert/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/ticket/concert/domain/seat/repository/SeatRepository.java
@@ -1,0 +1,7 @@
+package com.ticket.concert.domain.seat.repository;
+
+import com.ticket.concert.domain.seat.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+}

--- a/src/main/java/com/ticket/concert/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/ticket/concert/domain/seat/repository/SeatRepository.java
@@ -3,5 +3,8 @@ package com.ticket.concert.domain.seat.repository;
 import com.ticket.concert.domain.seat.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+    List<Seat> findByProductIdAndDeleted(Long productId, Boolean deleted);
 }

--- a/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
+++ b/src/main/java/com/ticket/concert/global/exception/constant/ErrorCode.java
@@ -44,7 +44,10 @@ public enum ErrorCode {
     INVALID_BOOKING_PERIOD(HttpStatus.BAD_REQUEST, "P002", "예매 마감 일시는 시작 일시보다 빠를 수 없습니다."),
     PAST_SCHEDULE(HttpStatus.BAD_REQUEST, "P003", "공연·예매 일정은 현재 시각 이후여야 합니다."),
     BOOKING_AFTER_SHOW_START(HttpStatus.BAD_REQUEST, "P004", "예매는 공연 시작 전에 마감되어야 합니다."),
-    NOTFOUND_PRODUCT(HttpStatus.BAD_REQUEST, "P005", "찾을 수 없는 상품입니다.");
+    NOTFOUND_PRODUCT(HttpStatus.BAD_REQUEST, "P005", "찾을 수 없는 상품입니다."),
+
+    // Seat Inventory
+    NOTFOUND_SEAT_INVENTORY(HttpStatus.BAD_REQUEST, "SI001", "찾을 수 없는 좌석 슬롯입니다.");
 
 
 

--- a/src/main/java/com/ticket/concert/presentation/PerformanceController.java
+++ b/src/main/java/com/ticket/concert/presentation/PerformanceController.java
@@ -1,0 +1,26 @@
+package com.ticket.concert.presentation;
+
+import com.ticket.concert.application.Performance.PerformanceService;
+import com.ticket.concert.application.dto.performance.response.PerformanceResponse;
+import com.ticket.concert.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class PerformanceController {
+
+    private final PerformanceService performanceService;
+
+    @GetMapping(value = "/v1/performance/{productId}")
+    public ApiResponse<List<PerformanceResponse>> getPerformance(@PathVariable Long productId) {
+        List<PerformanceResponse> performancesResponse = performanceService.getPerformances(productId);
+        return ApiResponse.success(performancesResponse);
+    }
+}

--- a/src/main/java/com/ticket/concert/presentation/SeatController.java
+++ b/src/main/java/com/ticket/concert/presentation/SeatController.java
@@ -1,0 +1,27 @@
+package com.ticket.concert.presentation;
+
+import com.ticket.concert.application.dto.seat.response.SeatResponse;
+import com.ticket.concert.application.seat.SeatService;
+import com.ticket.concert.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @GetMapping(value = "/v1/seat/{productId}")
+    public ApiResponse<List<SeatResponse>> getSeat(@PathVariable Long productId) {
+        List<SeatResponse> seats = seatService.getSeats(productId);
+        return ApiResponse.success(seats);
+    }
+
+}

--- a/src/main/java/com/ticket/concert/presentation/SeatInventoryController.java
+++ b/src/main/java/com/ticket/concert/presentation/SeatInventoryController.java
@@ -1,0 +1,28 @@
+package com.ticket.concert.presentation;
+
+import com.ticket.concert.application.dto.seatInventory.request.SeatInventoryRequest;
+import com.ticket.concert.application.dto.seatInventory.response.SeatInventoryResponse;
+import com.ticket.concert.application.seatInventory.SeatInventoryService;
+import com.ticket.concert.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class SeatInventoryController {
+
+    private final SeatInventoryService seatInventoryService;
+
+    @GetMapping(value = "/v1/seat-inventory")
+    public ApiResponse<List<SeatInventoryResponse>> getSeatInventory(@Valid @ModelAttribute SeatInventoryRequest request) {
+        List<SeatInventoryResponse> seatInventory = seatInventoryService.getSeatInventory(request);
+        return ApiResponse.success(seatInventory);
+    }
+}


### PR DESCRIPTION
## 📝 작업 개요
- 좌석 조회 기능을 개발했습니다. 

## 🔗 관련 이슈
- Related to #36 

## 🛠️ 작업 내용

- [x] 회차 목록 조회 API 엔드포인트 구현 (`v1/performance/{productId}`)
- [x] 상품 좌석 조회 API 엔드포인트 구현 (`/v1/seat-inventory`)
- [x] 요청값 검증 및 예외 처리
- [ ] 기능 테스트

## 💬 비고
- 좌석 생성 API를 만들지 않아 DB에 더미 데이터를 넣어 동작 확인했습니다.
  - 회차 목록 생성 시 seat_inventory 테이블에도 맞는 데이터가 추가되어야합니다.)
- 좌석 조회 및 선점 순서
  1. 상품 페이지 진입
  2. 회차 목록 조회 (회차 목록 조회 API 사용)
  3. 남은 좌석 노출 (상품 좌석 조회 API 사용)
  4. 좌석 클릭/선점 (다음 PR에서 기능 구현 예정) ← `여기까지 진행`
  5. 예매
- DDL 일부 변경
  - seat_inventory 테이블 user_id, heldUntil 제약 조건 변경(`NOT NULL` → `NULL`)
  - inventory_status, performance_status 컬럼명 변경(`status`)